### PR TITLE
fix: removed the git repo link as this is a private repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,10 +63,6 @@
     "lodash": "^4.17.21",
     "ts-node": "^10.5.0"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Voltz-Protocol/v1-subgraph.git"
-  },
   "lint-staged": {
     "src/**/*.ts": [
       "eslint --fix"


### PR DESCRIPTION
Accidentally added the github repo link even though this is a private repo. Removed it in this commit. 